### PR TITLE
Change auto_ptr to unique_ptr

### DIFF
--- a/SMTPlan/src/VALfiles/include/RepairAdvice.h
+++ b/SMTPlan/src/VALfiles/include/RepairAdvice.h
@@ -52,7 +52,7 @@
 #include <memory>
 
 
-using std::auto_ptr;
+using std::unique_ptr;
 
 namespace VAL {
   
@@ -198,19 +198,19 @@ virtual MutexViolation *
 
 class ErrorLog {
 private:
-  static auto_ptr<UnsatConditionFactory> fac;
+  static unique_ptr<UnsatConditionFactory> fac;
   
   vector<const UnsatCondition *> conditions; 
 public:
   template<typename Fac>
   static void replace() { 
-  	auto_ptr<Fac> f(new Fac);
+  	unique_ptr<Fac> f(new Fac);
   	fac = f;
   };
   template<typename Fac>
   static void replace(Fac * f)
   {
-  	auto_ptr<Fac> nf(f);
+  	unique_ptr<Fac> nf(f);
   	fac = nf;
   };
   ErrorLog() {};

--- a/SMTPlan/src/VALfiles/include/TypedAnalyser.h
+++ b/SMTPlan/src/VALfiles/include/TypedAnalyser.h
@@ -789,7 +789,7 @@ struct specEPSBuilder : public EPSBuilder {
 
 class Associater {
 public:
-	static auto_ptr<EPSBuilder> buildEPS;
+	static unique_ptr<EPSBuilder> buildEPS;
 	virtual ~Associater() {};
 	virtual Associater * lookup(pddl_type * p)
 	{

--- a/SMTPlan/src/VALfiles/include/ptree.h
+++ b/SMTPlan/src/VALfiles/include/ptree.h
@@ -69,7 +69,7 @@ using std::list;
 using std::map;
 using std::cout;
 using std::string;
-using std::auto_ptr;
+using std::unique_ptr;
 using std::ostream;
 
 namespace VAL {
@@ -223,14 +223,14 @@ extern analysis* current_analysis;
 class parse_category
 {
 protected:
-	static auto_ptr<WriteController> wcntr;
+	static unique_ptr<WriteController> wcntr;
 public:
     parse_category() {};
     virtual ~parse_category() {};
     virtual void display(int ind) const;
     virtual void write(ostream & o) const {};
     virtual void visit(VisitController * v) const {};
-    static void setWriteController(auto_ptr<WriteController> w);
+    static void setWriteController(unique_ptr<WriteController> w);
     static WriteController * recoverWriteController();
 };
 
@@ -308,7 +308,7 @@ class symbol_table : public map<string,symbol_class*>
 {
 private:
 	typedef map<string,symbol_class*> _Base;
-	auto_ptr<SymbolFactory<symbol_class> > factory;
+	unique_ptr<SymbolFactory<symbol_class> > factory;
 
 public :
 
@@ -316,15 +316,15 @@ public :
 
 	void setFactory(SymbolFactory<symbol_class> * sf)
 	{
-		auto_ptr<SymbolFactory<symbol_class> > x(sf);
-		factory = x;
+		unique_ptr<SymbolFactory<symbol_class> > x(sf);
+		factory = std::move(x);
 	};
 
 	template<class T>
 	void replaceFactory()
 	{
-		auto_ptr<SymbolFactory<symbol_class> > x(new SpecialistSymbolFactory<symbol_class,T>());
-		factory = x;
+		unique_ptr<SymbolFactory<symbol_class> > x(new SpecialistSymbolFactory<symbol_class,T>());
+		factory = std::move(x);
 	};
 
     typedef typename _Base::iterator iterator;
@@ -1864,8 +1864,8 @@ public:
 class analysis
 {
 private:
-	auto_ptr<VarTabFactory> varTabFactory;
-	auto_ptr<StructureFactory> strucFactory;
+	unique_ptr<VarTabFactory> varTabFactory;
+	unique_ptr<StructureFactory> strucFactory;
 
 public:
 	var_symbol_table * buildPredTab() {return varTabFactory->buildPredTab();};
@@ -1894,14 +1894,14 @@ public:
 
 	void setFactory(VarTabFactory * vf)
 	{
-		auto_ptr<VarTabFactory> x(vf);
-		varTabFactory = x;
+		unique_ptr<VarTabFactory> x(vf);
+		varTabFactory = std::move(x);
 	};
 
 	void setFactory(StructureFactory * sf)
 	{
-		auto_ptr<StructureFactory> x(sf);
-		strucFactory = x;
+		unique_ptr<StructureFactory> x(sf);
+		strucFactory = std::move(x);
 	};
 
     var_symbol_table_stack var_tab_stack;

--- a/SMTPlan/src/VALfiles/src/DYNA.cpp
+++ b/SMTPlan/src/VALfiles/src/DYNA.cpp
@@ -107,8 +107,8 @@ int main(int argc,char * argv[])
 
 	    // Output syntax tree
 	    dyna = new DYNATranslator(current_analysis);
-	    auto_ptr<WriteController> ts 
-	    		= auto_ptr<WriteController>(dyna);
+	    unique_ptr<WriteController> ts 
+	    		= unique_ptr<WriteController>(dyna);
 	    // NOTE: We pass responsibility for dyna into parse_category. There
 	    // is no need to garbage collect it. BUT we access dyna later through
 	    // this pointer, so beware!

--- a/SMTPlan/src/VALfiles/src/LPGP.cpp
+++ b/SMTPlan/src/VALfiles/src/LPGP.cpp
@@ -107,8 +107,8 @@ int main(int argc,char * argv[])
 
 	    // Output syntax tree
 	    lpgp = new LPGPTranslator(current_analysis);
-	    auto_ptr<WriteController> ts 
-	    		= auto_ptr<WriteController>(lpgp);
+	    unique_ptr<WriteController> ts 
+	    		= unique_ptr<WriteController>(lpgp);
 	    // NOTE: We pass responsibility for lpgp into parse_category. There
 	    // is no need to garbage collect it. BUT we access lpgp later through
 	    // this pointer, so beware!

--- a/SMTPlan/src/VALfiles/src/Proposition.cpp
+++ b/SMTPlan/src/VALfiles/src/Proposition.cpp
@@ -3005,8 +3005,8 @@ void QfiedGoal::write(ostream & o) const
 	for(var_symbol_list::const_iterator i = qf->getVars()->begin();i != qf->getVars()->end();++i)
 	{
 	*/
-	auto_ptr<WriteController> w(parse_category::recoverWriteController());
-	auto_ptr<WriteController> p(new PrettyPrinter());
+	unique_ptr<WriteController> w(parse_category::recoverWriteController());
+	unique_ptr<WriteController> p(new PrettyPrinter());
 	parse_category::setWriteController(p);
   o<< *qg << "\n";
   	parse_category::setWriteController(w);

--- a/SMTPlan/src/VALfiles/src/Relax.cpp
+++ b/SMTPlan/src/VALfiles/src/Relax.cpp
@@ -107,8 +107,8 @@ int main(int argc,char * argv[])
 
 	    // Output syntax tree
 	    dyna = new RelaxTranslator(current_analysis);
-	    auto_ptr<WriteController> ts 
-	    		= auto_ptr<WriteController>(dyna);
+	    unique_ptr<WriteController> ts 
+	    		= unique_ptr<WriteController>(dyna);
 	    // NOTE: We pass responsibility for dyna into parse_category. There
 	    // is no need to garbage collect it. BUT we access dyna later through
 	    // this pointer, so beware!

--- a/SMTPlan/src/VALfiles/src/RepairAdvice.cpp
+++ b/SMTPlan/src/VALfiles/src/RepairAdvice.cpp
@@ -50,7 +50,7 @@
 
 namespace VAL {
   
-auto_ptr<UnsatConditionFactory> ErrorLog::fac(new UnsatConditionFactory);
+unique_ptr<UnsatConditionFactory> ErrorLog::fac(new UnsatConditionFactory);
 
 string UnsatCondition::getAdviceString() const
 {

--- a/SMTPlan/src/VALfiles/src/TIM.cpp
+++ b/SMTPlan/src/VALfiles/src/TIM.cpp
@@ -79,8 +79,8 @@ void performTIMAnalysis(char * argv[])
     current_analysis->const_tab.replaceFactory<TIMobjectSymbol>();
     current_analysis->op_tab.replaceFactory<TIMactionSymbol>();
     current_analysis->setFactory(new TIMfactory());
-    auto_ptr<EPSBuilder> eps(new specEPSBuilder<TIMpredSymbol>());
-    Associater::buildEPS = eps;
+    unique_ptr<EPSBuilder> eps(new specEPSBuilder<TIMpredSymbol>());
+    Associater::buildEPS = std::move(eps);
     
     ifstream* current_in_stream;
     yydebug=0; // Set to 1 to output yacc trace 

--- a/SMTPlan/src/VALfiles/src/TypeStrip.cpp
+++ b/SMTPlan/src/VALfiles/src/TypeStrip.cpp
@@ -105,8 +105,8 @@ int main(int argc,char * argv[])
 	    yyparse();
 
 	    // Output syntax tree
-	    auto_ptr<WriteController> ts 
-	    		= auto_ptr<WriteController>(new TypeStripWriteController(current_analysis));
+	    unique_ptr<WriteController> ts 
+	    		= unique_ptr<WriteController>(new TypeStripWriteController(current_analysis));
 	    parse_category::setWriteController(ts);
 	    if (top_thing) 
 		{

--- a/SMTPlan/src/VALfiles/src/TypedAnalyser.cpp
+++ b/SMTPlan/src/VALfiles/src/TypedAnalyser.cpp
@@ -141,7 +141,7 @@ vector<double> extended_pred_symbol::getTimedAchievers(Environment * f,const pro
 PropInfoFactory * PropInfoFactory::pf = 0;
 
 
-auto_ptr<EPSBuilder> Associater::buildEPS(new EPSBuilder());
+unique_ptr<EPSBuilder> Associater::buildEPS(new EPSBuilder());
 
 // Associater associates predicates with their various type-specific versions.
 // So, if a predicate is overloaded to work with multiple types this will store

--- a/SMTPlan/src/VALfiles/src/ptree.cpp
+++ b/SMTPlan/src/VALfiles/src/ptree.cpp
@@ -52,14 +52,14 @@
 
 namespace VAL {
 
-auto_ptr<WriteController> parse_category::wcntr = auto_ptr<WriteController>(new DebugWriteController);
+unique_ptr<WriteController> parse_category::wcntr = unique_ptr<WriteController>(new DebugWriteController);
 
 WriteController * parse_category::recoverWriteController()
 {
 	return wcntr.release();
 };
 
-void parse_category::setWriteController(auto_ptr<WriteController> w) {wcntr = w;};
+void parse_category::setWriteController(unique_ptr<WriteController> w) {wcntr = std::move(w);};
 
 void parse_category::display(int ind) const
 {


### PR DESCRIPTION
This change only replaces auto_ptr with unique_ptr, and every assignment with a unique_ptr is replaced with a std::move( ).  Builds in recent compilers without warnings or errors.  Runs fine on the benchmarks.