### PR TITLE
Fix LHS vs RHS in arithmetic expressions.

### DIFF
--- a/SMTPlan/src/EncoderHappening.cpp
+++ b/SMTPlan/src/EncoderHappening.cpp
@@ -1352,9 +1352,9 @@ namespace SMTPlan {
 		s->getLHS()->visit(this);
 		s->getRHS()->visit(this);
 
-		z3::expr lhs = enc_expression_stack.back();
-		enc_expression_stack.pop_back();
 		z3::expr rhs = enc_expression_stack.back();
+		enc_expression_stack.pop_back();
+		z3::expr lhs = enc_expression_stack.back();
 		enc_expression_stack.pop_back();
 		enc_expression_stack.push_back(lhs + rhs);
 	}
@@ -1364,9 +1364,9 @@ namespace SMTPlan {
 		s->getLHS()->visit(this);
 		s->getRHS()->visit(this);
 
-		z3::expr lhs = enc_expression_stack.back();
-		enc_expression_stack.pop_back();
 		z3::expr rhs = enc_expression_stack.back();
+		enc_expression_stack.pop_back();
+		z3::expr lhs = enc_expression_stack.back();
 		enc_expression_stack.pop_back();
 		enc_expression_stack.push_back(lhs - rhs);
 	}
@@ -1376,9 +1376,9 @@ namespace SMTPlan {
 		s->getLHS()->visit(this);
 		s->getRHS()->visit(this);
 
-		z3::expr lhs = enc_expression_stack.back();
-		enc_expression_stack.pop_back();
 		z3::expr rhs = enc_expression_stack.back();
+		enc_expression_stack.pop_back();
+		z3::expr lhs = enc_expression_stack.back();
 		enc_expression_stack.pop_back();
 		enc_expression_stack.push_back(lhs * rhs);
 	}


### PR DESCRIPTION
Fixes #19.

`visit_div_expression` already had the correct method of popping the RHS first then the LHS. However, plus, minus and mul all switched the order and called the first thing popped from the stack the LHS. For plus and mul, this doesn't affect the correctness, but it lead to minus being interpreted backwards (see the linked issue). I think this should fix that issue, but I'm not familiar with the code base, so please let me know if there are other places this change would need to be made too.